### PR TITLE
Apply policy for @atomist/automation-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "email": "slimslenderslacks@gmail.com"
   },
   "peerDependencies": {
-    "@atomist/automation-client": ">=1.3.0"
+    "@atomist/automation-client": "^1.6.2"
   },
   "dependencies": {
     "@cljs-oss/module-deps": "^1.1.1",
@@ -22,7 +22,7 @@
     "yargs": "^12.0.1"
   },
   "devDependencies": {
-    "@atomist/automation-client": "^1.3.0",
+    "@atomist/automation-client": "^1.6.2",
     "npm-run-all": "^4.1.2"
   },
   "bin": {


### PR DESCRIPTION
Apply policy `npm-project-deps::atomist::automation-client`:

**New NPM Package Policy**
Policy version for NPM package *@atomist/automation-client* is `^1.6.2`.
Project *atomist/clj-editors/master* is currently configured to use version `^1.3.0`.

_NPM dependencies_
```@atomist/automation-client (^1.6.2)```

---
<details>
  <summary><img src="https://images.atomist.com/logo/atomist-color-mark-small.png" height="20" valign="bottom"/>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:npm-project-deps::atomist::automation-client=87efccbdfd36903fd5d1f0d492c5f0d6a37287a0901717d24f21eaf7a75136fe]</code>
</details>